### PR TITLE
fix solidity version

### DIFF
--- a/SimpleStorage.sol
+++ b/SimpleStorage.sol
@@ -1,7 +1,7 @@
 // I'm a comment!
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.8;
+pragma solidity ^0.8.8;
 // pragma solidity ^0.8.0;
 // pragma solidity >=0.8.0 <0.9.0;
 


### PR DESCRIPTION
IMO this is better for very new developers because these days Remix defaults to a higher version and it causes an error.