### PR TITLE
Update SimpleStorage.sol

### DIFF
--- a/SimpleStorage.sol
+++ b/SimpleStorage.sol
@@ -1,8 +1,7 @@
 // I'm a comment!
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.8;
-// pragma solidity ^0.8.0;
+pragma solidity ^0.8.0;
 // pragma solidity >=0.8.0 <0.9.0;
 
 contract SimpleStorage {


### PR DESCRIPTION
pragma solidity 0.8.8;
 do not compile anymore.

Description:

ParserError: Source file requires different compiler version (current compiler is 0.8.26+commit.8a97fa7a.Emscripten.clang) - note that nightly builds are considered to be strictly less than the released version
 --> contracts/SimpleStorage.sol:4:1:
  |
4 | pragma solidity 0.8.8;